### PR TITLE
Add support for setting ping timeout

### DIFF
--- a/RealReachability/Ping/PingHelper.h
+++ b/RealReachability/Ping/PingHelper.h
@@ -18,6 +18,9 @@ extern NSString *const kPingResultNotification;
 /// Think about that: if you never set this, we don't know where to ping.
 @property (nonatomic, copy) NSString *host;
 
+// Ping timeout. Default is 2 seconds
+@property (nonatomic, assign) NSTimeInterval timeout;
+
 + (instancetype)sharedInstance;
 
 /**

--- a/RealReachability/Ping/PingHelper.m
+++ b/RealReachability/Ping/PingHelper.m
@@ -34,7 +34,7 @@ NSString *const kPingResultNotification = @"kPingResultNotification";
     if ((self = [super init]))
     {
         _isPinging = NO;
-        
+        _timeout = 2.0f;
         _completionBlocks = [NSMutableArray array];
     }
     return self;
@@ -115,7 +115,7 @@ NSString *const kPingResultNotification = @"kPingResultNotification";
     self.pingFoundation.delegate = self;
     [self.pingFoundation start];
     
-    [self performSelector:@selector(pingTimeOut) withObject:nil afterDelay:2.0f];
+    [self performSelector:@selector(pingTimeOut) withObject:nil afterDelay:self.timeout];
 }
 
 - (void)setHost:(NSString *)host

--- a/RealReachability/RealReachability.h
+++ b/RealReachability/RealReachability.h
@@ -59,6 +59,9 @@ typedef NS_ENUM(NSInteger, WWANAccessType) {
 /// If exceeded, the value will be reset to 0.3f or 60.0f (the closer one).
 @property (nonatomic, assign) float autoCheckInterval;
 
+// Timeout used for ping. Default is 2 seconds
+@property (nonatomic, assign) NSTimeInterval pingTimeout;
+
 + (instancetype)sharedInstance;
 
 - (void)startNotifier;

--- a/RealReachability/RealReachability.m
+++ b/RealReachability/RealReachability.m
@@ -19,6 +19,7 @@
 
 #define kDefaultHost @"www.apple.com"
 #define kDefaultCheckInterval 2.0f
+#define kDefaultPingTimeout 2.0f
 
 #define kMinAutoCheckInterval 0.3f
 #define kMaxAutoCheckInterval 60.0f
@@ -63,6 +64,7 @@ NSString *const kRealReachabilityChangedNotification = @"kRealReachabilityChange
         
         _hostForPing = kDefaultHost;
         _autoCheckInterval = kDefaultCheckInterval;
+        _pingTimeout = kDefaultPingTimeout;
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(appBecomeActive)
@@ -131,6 +133,7 @@ NSString *const kRealReachabilityChangedNotification = @"kRealReachabilityChange
                                                object:nil];
     
     GPingHelper.host = _hostForPing;
+    GPingHelper.timeout = self.pingTimeout;
     [self autoCheckReachability];
 }
 
@@ -264,6 +267,10 @@ NSString *const kRealReachabilityChangedNotification = @"kRealReachabilityChange
     GPingHelper.host = _hostForPing;
 }
 
+- (void)setPingTimeout:(NSTimeInterval)pingTimeout {
+    GPingHelper.timeout = pingTimeout;
+}
+
 - (WWANAccessType)currentWWANtype
 {
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0)
@@ -329,7 +336,8 @@ NSString *const kRealReachabilityChangedNotification = @"kRealReachabilityChange
         self.autoCheckInterval = kMaxAutoCheckInterval;
     }
     
-    dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, self.autoCheckInterval*60*NSEC_PER_SEC);
+    
+    dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.autoCheckInterval*60*NSEC_PER_SEC));
     __weak __typeof(self)weakSelf = self;
     dispatch_after(time, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         __strong __typeof(weakSelf)strongSelf = weakSelf;


### PR DESCRIPTION
Add support for setting ping timeout. 

In certain network conditions, the default 2 second timeout for the ping test can be too short resulting in false failures. This feature adds support to setting the timeout to something custom but keeps the default at 2 seconds. 

It might be worth changing the default value from 2 seconds to 5 seconds as 5 seconds appears to be sufficient when on a network with high latency. This has been tested using the "Network Link Conditioner" developer tool.

