### PR TITLE
Fix for _pingTimeout instance variable not changing

### DIFF
--- a/RealReachability/RealReachability.m
+++ b/RealReachability/RealReachability.m
@@ -268,6 +268,7 @@ NSString *const kRealReachabilityChangedNotification = @"kRealReachabilityChange
 }
 
 - (void)setPingTimeout:(NSTimeInterval)pingTimeout {
+    _pingTimeout = pingTimeout;
     GPingHelper.timeout = pingTimeout;
 }
 


### PR DESCRIPTION
Fix _pingTimeout instance variable not changing when -setPingTimeout: is invoked