### PR TITLE
Added support for Xcode 16

### DIFF
--- a/RealReachability/Ping/PingFoundation.h
+++ b/RealReachability/Ping/PingFoundation.h
@@ -48,6 +48,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <sys/socket.h>
 
 #if TARGET_OS_EMBEDDED || TARGET_IPHONE_SIMULATOR
 #import <CFNetwork/CFNetwork.h>


### PR DESCRIPTION
Fixing error: declaration of 'sa_family_t' must be imported from module 'darwin.posix.sys.types.sa_family_t' before it is required